### PR TITLE
fix for when armature scale isn't present

### DIFF
--- a/src/library_animations/parse-skeletal-animations.js
+++ b/src/library_animations/parse-skeletal-animations.js
@@ -30,7 +30,9 @@ function ParseLibraryAnimations (library_animations, jointBindPoses, visualScene
         var currentJointMatrix = currentJointPoseMatrices.slice(16 * keyframeIndex, 16 * keyframeIndex + 16)
         if (!jointRelationships[animatedJointName].parent) {
           // apply library visual scene transformations to top level parent joint(s)
-          mat4Scale(currentJointMatrix, currentJointMatrix, armatureScale)
+          if (armatureScale) {
+            mat4Scale(currentJointMatrix, currentJointMatrix, armatureScale)
+          }
         }
 
         keyframeJointMatrices[currentKeyframes[keyframeIndex]][animatedJointName] = currentJointMatrix

--- a/src/library_visual_scenes/parse-visual-scenes.js
+++ b/src/library_visual_scenes/parse-visual-scenes.js
@@ -11,8 +11,9 @@ function ParseVisualScenes (library_visual_scenes) {
     // This is the location of all top level parent nodes
     if (node.node) {
       // node.node is the location of all top level nodes
-      armatureScale = node.scale && node.scale[0]
-        ? node.scale[0]._.split(' ').map(Number) : null
+      if (node.scale && node.scale.length > 0) {
+        armatureScale = node.scale[0]._.split(' ').map(Number)
+      }
       parsedJoints = parseJoints(node.node)
     }
     /*

--- a/src/library_visual_scenes/parse-visual-scenes.js
+++ b/src/library_visual_scenes/parse-visual-scenes.js
@@ -11,7 +11,8 @@ function ParseVisualScenes (library_visual_scenes) {
     // This is the location of all top level parent nodes
     if (node.node) {
       // node.node is the location of all top level nodes
-      armatureScale = node.scale[0]._.split(' ').map(Number)
+      armatureScale = node.scale && node.scale[0]
+        ? node.scale[0]._.split(' ').map(Number) : null
       parsedJoints = parseJoints(node.node)
     }
     /*

--- a/src/library_visual_scenes/parse-visual-scenes.js
+++ b/src/library_visual_scenes/parse-visual-scenes.js
@@ -6,7 +6,7 @@ function ParseVisualScenes (library_visual_scenes) {
   var parsedJoints = []
 
   // Some .dae files will export a shrunken model. Here's how to scale it
-  var armatureScale = []
+  var armatureScale = null
   visualScene.node.forEach(function (node) {
     // This is the location of all top level parent nodes
     if (node.node) {


### PR DESCRIPTION
Before with an exported collada file from blender, I was getting this error:

```
$ node parse.js 
events.js:154
      throw er; // Unhandled 'error' event
      ^

TypeError: Cannot read property '0' of undefined
    at /home/substack/projects/collada-dae-parser/src/library_visual_scenes/parse-visual-scenes.js:14:33
    at Array.forEach (native)
    at ParseVisualScenes (/home/substack/projects/collada-dae-parser/src/library_visual_scenes/parse-visual-scenes.js:10:20)
    at /home/substack/projects/collada-dae-parser/src/parse-collada.js:20:27
    at Parser.<anonymous> (/home/substack/projects/collada-dae-parser/node_modules/xml2js/lib/xml2js.js:484:18)
    at emitOne (events.js:90:13)
    at Parser.emit (events.js:182:7)
    at Object.onclosetag (/home/substack/projects/collada-dae-parser/node_modules/xml2js/lib/xml2js.js:445:26)
    at emit (/home/substack/projects/collada-dae-parser/node_modules/sax/lib/sax.js:640:35)
    at emitNode (/home/substack/projects/collada-dae-parser/node_modules/sax/lib/sax.js:645:5)
```

This patch tests for the presence of `node.scale` first, and only sets the armatureScale if `node.scale` exists.