### PR TITLE
using a synchronous xml parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ dae2json my-3d-modal.dae > parsed-model.json
 
 ### `parseDae(xmlFile, callback)` -> `object`
 
+This function returns the parsed collada object.
+
 #### xmlFile
 
 *Required*
@@ -66,7 +68,7 @@ Your collada file data. Not the filename, the file contents.
 
 #### callback
 
-*Required*
+*Optional*
 
 Type: `function`
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
   },
   "dependencies": {
     "gl-mat4": "^1.1.4",
-    "xml2js": "^0.4.16"
+    "xml-parser": "^1.2.1"
   }
 }

--- a/src/parse-collada.js
+++ b/src/parse-collada.js
@@ -50,7 +50,7 @@ function ParseCollada (colladaXML, callback) {
     parsedObject.vertexUVs = parsedLibraryGeometries.vertexUVs
   }
   if (callback) callback(null, parsedObject)
-  return result
+  return parsedObject
 }
 
 function compactXML (res, xml) {

--- a/src/parse-collada.js
+++ b/src/parse-collada.js
@@ -1,4 +1,4 @@
-var parseXML = require('xml2js').parseString
+var xmlparser = require('xml-parser')
 var parseLibraryGeometries = require('./library_geometries/parse-library-geometries.js')
 var parseLibraryVisualScenes = require('./library_visual_scenes/parse-visual-scenes.js')
 var parseLibraryControllers = require('./library_controllers/parse-library-controllers.js')
@@ -11,44 +11,61 @@ module.exports = ParseCollada
 // Use input, accessor, and param attributes instead of hard coding lookups
 // Clean Up Code / less confusing var names
 function ParseCollada (colladaXML, callback) {
-  parseXML(colladaXML, function (err, result) {
-    if (err) { return callback(err) }
+  var result = compactXML({}, xmlparser(colladaXML.toString()).root)
+  result = { COLLADA: result.COLLADA[0] }
 
-    var parsedObject = {}
-    var parsedLibraryGeometries = parseLibraryGeometries(result.COLLADA.library_geometries)
+  var parsedObject = {}
+  var parsedLibraryGeometries = parseLibraryGeometries(result.COLLADA.library_geometries)
 
-    var visualSceneData = parseLibraryVisualScenes(result.COLLADA.library_visual_scenes)
+  var visualSceneData = parseLibraryVisualScenes(result.COLLADA.library_visual_scenes)
 
-    var jointBindPoses
-    if (result.COLLADA.library_controllers) {
-      var controllerData = parseLibraryControllers(result.COLLADA.library_controllers)
-      if (controllerData.vertexJointWeights && Object.keys(controllerData.vertexJointWeights) .length > 0) {
-        parsedObject.vertexJointWeights = controllerData.vertexJointWeights
-        jointBindPoses = controllerData.jointBindPoses
-      }
+  var jointBindPoses
+  if (result.COLLADA.library_controllers) {
+    var controllerData = parseLibraryControllers(result.COLLADA.library_controllers)
+    if (controllerData.vertexJointWeights && Object.keys(controllerData.vertexJointWeights) .length > 0) {
+      parsedObject.vertexJointWeights = controllerData.vertexJointWeights
+      jointBindPoses = controllerData.jointBindPoses
     }
+  }
 
-    // TODO: Also parse interpolation/intangent/outtangent
-    if (result.COLLADA.library_animations) {
-      parsedObject.keyframes = parseLocRotScaleAnim(result.COLLADA.library_animations[0].animation)
-      if (Object.keys(parsedObject.keyframes).length === 0) {
-        delete parsedObject.keyframes
-      }
-      var keyframes = parseSkeletalAnimations(result.COLLADA.library_animations, jointBindPoses, visualSceneData)
-      if (Object.keys(keyframes).length > 0) {
-        parsedObject.keyframes = keyframes
-      }
+  // TODO: Also parse interpolation/intangent/outtangent
+  if (result.COLLADA.library_animations) {
+    parsedObject.keyframes = parseLocRotScaleAnim(result.COLLADA.library_animations[0].animation)
+    if (Object.keys(parsedObject.keyframes).length === 0) {
+      delete parsedObject.keyframes
     }
+    var keyframes = parseSkeletalAnimations(result.COLLADA.library_animations, jointBindPoses, visualSceneData)
+    if (Object.keys(keyframes).length > 0) {
+      parsedObject.keyframes = keyframes
+    }
+  }
 
-    // Return our parsed collada object
-    parsedObject.vertexNormalIndices = parsedLibraryGeometries.vertexNormalIndices
-    parsedObject.vertexNormals = parsedLibraryGeometries.vertexNormals
-    parsedObject.vertexPositionIndices = parsedLibraryGeometries.vertexPositionIndices
-    parsedObject.vertexPositions = parsedLibraryGeometries.vertexPositions
-    if (parsedLibraryGeometries.vertexUVs.length > 0) {
-      parsedObject.vertexUVIndices = parsedLibraryGeometries.vertexUVIndices
-      parsedObject.vertexUVs = parsedLibraryGeometries.vertexUVs
-    }
-    callback(null, parsedObject)
-  })
+  // Return our parsed collada object
+  parsedObject.vertexNormalIndices = parsedLibraryGeometries.vertexNormalIndices
+  parsedObject.vertexNormals = parsedLibraryGeometries.vertexNormals
+  parsedObject.vertexPositionIndices = parsedLibraryGeometries.vertexPositionIndices
+  parsedObject.vertexPositions = parsedLibraryGeometries.vertexPositions
+  if (parsedLibraryGeometries.vertexUVs.length > 0) {
+    parsedObject.vertexUVIndices = parsedLibraryGeometries.vertexUVIndices
+    parsedObject.vertexUVs = parsedLibraryGeometries.vertexUVs
+  }
+  if (callback) callback(null, parsedObject)
+  return result
+}
+
+function compactXML (res, xml) {
+  var txt = Object.keys(xml.attributes).length === 0 && xml.children.length === 0
+  var r = {}
+  if (!res[xml.name]) res[xml.name] = []
+  if (txt) {
+    r = xml.content || ''
+  } else {
+    r.$ = xml.attributes
+    r._ = xml.content || ''
+    xml.children.forEach(function (ch) {
+      compactXML(r, ch)
+    })
+  }
+  res[xml.name].push(r)
+  return res
 }

--- a/test/api/api.js
+++ b/test/api/api.js
@@ -34,6 +34,12 @@ test('Parse a default blender cube with an added texture', function (t) {
   })
 })
 
+test('Parse a default blender cube with an added texture without a callback', function (t) {
+  t.plan(1)
+  var parsedCube = parseCollada(tbdcColladaXML)
+  t.deepEqual(parsedCube, expectedTBDC)
+})
+
 test('Parse a default blender cube with an animation', function (t) {
   t.plan(1)
   parseCollada(animatedColladaXML, function (err, parsedAnimatedCube) {


### PR DESCRIPTION
This patch swaps out [xml2js][1] for [xml-parser][2] so that the collada parser can return an object directly without going through a callback.

I tried to make this change minimal to the existing code by formatting the xml-parser object in the way that the xml2js object was formatted previously. The callback is now optional so that the test suite and examples all work the same as before.

One upside is that the payload for the browser is much smaller. Before:

```
$ browserify . | uglifyjs -cm 2>/dev/null | gzip | wc -c
38274
```

After:

```
$ browserify . | uglifyjs -cm 2>/dev/null | gzip | wc -c
4221
```

[1]: https://npmjs.com/package/xml2js
[2]: https://npmjs.com/package/xml-parser