### PR TITLE
Adds recognition of triangle geometry and index list offsets.

### DIFF
--- a/src/library_geometries/parse-library-geometries.js
+++ b/src/library_geometries/parse-library-geometries.js
@@ -12,16 +12,15 @@ function ParseLibraryGeometries (library_geometries) {
   var geometryMesh = library_geometries[0].geometry[0].mesh[0]
   var source = geometryMesh.source
 
-  var indexList = geometryMesh.polylist || geometryMesh.triangles || null;
+  var indexList = geometryMesh.polylist || geometryMesh.triangles || null
   if (!indexList) {
-    console.error("Geometry must contain either 'polylist' or 'triangles' object.");
-    return false;
+    console.error("Geometry must contain either 'polylist' or 'triangles' object.")
+    return false
   }
 
-  //get index list offsets for vertex data - vertex, normal, texcoord
-  var vertexOffset, normalOffset, UVOffset
+  // Get index list offsets for vertex data - vertex, normal, texcoord
   var offsets = {}
-  indexList[0].input.forEach( function ( input ) {
+  indexList[0].input.forEach(function (input) {
     offsets[input.$.semantic.toLowerCase()] = parseInt(input.$.offset)
   })
 
@@ -39,7 +38,7 @@ function ParseLibraryGeometries (library_geometries) {
     }
     if (positionInArray % source.length === offsets.texcoord) {
       vertexUVIndices.push(Number(vertexIndex))
-    } 
+    }
   })
   var vertexPositions = source[0].float_array[0]._.split(' ').map(Number)
   var vertexNormals = source[1].float_array[0]._.split(' ').map(Number)

--- a/src/library_geometries/parse-library-geometries.js
+++ b/src/library_geometries/parse-library-geometries.js
@@ -12,20 +12,13 @@ function ParseLibraryGeometries (library_geometries) {
   var geometryMesh = library_geometries[0].geometry[0].mesh[0]
   var source = geometryMesh.source
 
-  var indexList;
-  if (geometryMesh.polylist) {
-    indexList = geometryMesh.polylist
-  }
-  else{
-    if (geometryMesh.triangles) {
-      indexList = geometryMesh.triangles
-    }
-    else {
-      console.error("Geometry must contain either 'polylist' or 'triangles' object.");
-    }
+  var indexList = geometryMesh.polylist || geometryMesh.triangles || null;
+  if (!indexList) {
+    console.error("Geometry must contain either 'polylist' or 'triangles' object.");
+    return false;
   }
 
-  //get index list offsets for vertex data
+  //get index list offsets for vertex data - vertex, normal, texcoord
   var vertexOffset, normalOffset, UVOffset
   var offsets = {}
   indexList[0].input.forEach( function ( input ) {
@@ -38,8 +31,6 @@ function ParseLibraryGeometries (library_geometries) {
   var vertexNormalIndices = []
   var vertexPositionIndices = []
   var vertexUVIndices = []
-  // TODO: This is currently dependent on a certain vertex data order
-  // we should instead read this order from the .dae file
   polylistIndices.forEach(function (vertexIndex, positionInArray) {
     if (positionInArray % source.length === offsets.vertex) {
       vertexPositionIndices.push(Number(vertexIndex))


### PR DESCRIPTION
- Geometry parser will read 'triangles' geometry list.
- Geometry parser will read using index list offsets, not assuming index order.

These changes are intended to make the tool compatible with triangulated meshes and meshes produced by the godot collada exporter: [https://github.com/godotengine/collada-exporter](https://github.com/godotengine/collada-exporter)